### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-dentoo.lt


### PR DESCRIPTION
カスタムドメイン設定のためにCNAMEファイルを置く必要はなくなっているので消す