### PR TITLE
アイコンのパス変える

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "background_color" : "#FFFFFF",
   "theme_color": "#FFFFFF",
   "icons": [{
-    "src": "/assets/images/icon.png",
+    "src": "assets/images/icon.png",
     "sizes": "512x512",
     "type": "image/png"
   }]


### PR DESCRIPTION
> Error while trying to use the following icon from the Manifest: https://dentoo.lt/assets/images/icon.png (Download error or resource isn't a valid image)

てエラーが出てる

https://stackoverflow.com/questions/43307278/progressive-web-app-site-cannot-be-installed-no-icon-available-to-display

pathを`/`から始めるなということだったので消した